### PR TITLE
Fix factory code for Symfony2.6+

### DIFF
--- a/_posts/2015-09-07-repositories-en-tant-que-services.md
+++ b/_posts/2015-09-07-repositories-en-tant-que-services.md
@@ -62,11 +62,17 @@ AppBundle/Resources/config/repositories.yml
 services:
     repository.user:
         class: Doctrine\ORM\EntityRepository
-        factory_service: doctrine.orm.default_entity_manager
-        factory_method: getRepository
+        factory: [@doctrine.orm.default_entity_manager, getRepository]
         arguments:
             - AppBundle\Entity\User
 {% endhighlight %}
+
+A noter si vous utilisez une version de Symfony inférieure à 2.6, il faudra utiliser l'ancienne manière d'utiliser la factory (merci à @FlavienMetivier pour l'information) :
+
+{% highlight yaml %}
+    factory_service: doctrine.orm.default_entity_manager
+    factory_method: getRepository
+{% hightlight %}
 
 AppBundle/Resources/config/managers.yml
 {% highlight yaml %}


### PR DESCRIPTION
L'exemple de la factory étant deprecated à partir de la 2.6, ajout de la nouvelle syntaxe
